### PR TITLE
docs: Remove redundant "Turbo" suffix from model

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -59,7 +59,7 @@ To avoid git clashes in the core directory, we recommend adding custom actions t
 
 ### Run with Llama
 
-You can run Llama 70B or 405B models by setting the `XAI_MODEL` environment variable to `meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo` or `meta-llama/Meta-Llama-3.1-405B-Instruct`
+You can run Llama 70B or 405B models by setting the `XAI_MODEL` environment variable to `meta-llama/Meta-Llama-3.1-70B-Instruct` or `meta-llama/Meta-Llama-3.1-405B-Instruct`
 
 ### Run with Grok
 


### PR DESCRIPTION
I noticed that the term "Turbo" was incorrectly added to the model names in the documentation.
Since this suffix isn't part of the official Llama model naming convention, I've removed it to align with the correct terminology.